### PR TITLE
consolidate default output path setting

### DIFF
--- a/lib/mix/tasks/systemd.ex
+++ b/lib/mix/tasks/systemd.ex
@@ -140,7 +140,7 @@ defmodule Mix.Tasks.Systemd do
       build_path: build_path,
 
       # Staging output directory for generated files
-      output_dir: Path.join(build_path, @output_dir),
+      output_dir: Path.join([build_path, @output_dir, "/lib/systemd/system"]),
 
       # Directory with templates which override defaults
       template_dir: @template_dir,
@@ -401,7 +401,7 @@ defmodule Mix.Tasks.Systemd.Generate do
   def run(args) do
     cfg = Mix.Tasks.Systemd.parse_args(args)
 
-    dest_dir = Path.join([cfg[:output_dir], "/lib/systemd/system"])
+    dest_dir = cfg[:output_dir]
     service_name = cfg[:service_name]
 
     write_template(cfg, dest_dir, "systemd.service", "#{service_name}.service")


### PR DESCRIPTION
Currently, it is adding `lib/systemd/system/` to user defined path.
This PR consolidated output path dest from 2 different locations.
Default path can now be override completely. 