### PR TITLE
made output_dir completely overridable from config

### DIFF
--- a/lib/mix/tasks/systemd.ex
+++ b/lib/mix/tasks/systemd.ex
@@ -46,8 +46,10 @@ defmodule Mix.Tasks.Systemd do
       |> Enum.join("")
 
     base_dir = user_config[:base_dir] || "/srv"
-
     build_path = Mix.Project.build_path()
+
+    output_dir =
+      user_config[:output_dir] || Path.join([build_path, @output_dir, "/lib/systemd/system"])
 
     defaults = [
       # Elixir application name
@@ -140,7 +142,7 @@ defmodule Mix.Tasks.Systemd do
       build_path: build_path,
 
       # Staging output directory for generated files
-      output_dir: Path.join([build_path, @output_dir, "/lib/systemd/system"]),
+      output_dir: output_dir,
 
       # Directory with templates which override defaults
       template_dir: @template_dir,

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule MixSystemd.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:ex_doc, "~> 0.21", only: :dev, runtime: false},
+      {:ex_doc, "~> 0.21", only: :dev, runtime: false}
       # {:dialyxir, "~> 0.5.1", only: [:dev, :test], runtime: false},
     ]
   end


### PR DESCRIPTION
## Current Behaviour

`output_dir` can only be partially override.

## Updated Behaviour

Made `output_dir` overridable as a whole.