### PR TITLE
Allow App Name To Be Set And Trickle Down

### DIFF
--- a/lib/mix/tasks/systemd.ex
+++ b/lib/mix/tasks/systemd.ex
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.Systemd do
     mix_config = Mix.Project.config()
 
     IO.puts("============================================================")
-    cfg = create_config(IO.inspect(mix_config), IO.inspect(user_config))
+    cfg = create_config(mix_config, user_config)
     IO.puts("============================================================")
     cfg
   end
@@ -237,7 +237,10 @@ defmodule Mix.Tasks.Systemd do
     ]
 
     # Override values from user config
+    IO.inspect(defaults)
+    IO.inspect(user_config)
     cfg = Keyword.merge(defaults, user_config)
+    IO.inspect(cfg)
 
     # Calcualate values from other things
     cfg =

--- a/lib/mix/tasks/systemd.ex
+++ b/lib/mix/tasks/systemd.ex
@@ -19,7 +19,9 @@ defmodule Mix.Tasks.Systemd do
     user_config = Application.get_all_env(@app) |> Keyword.merge(overrides)
     mix_config = Mix.Project.config()
 
-    create_config(mix_config, user_config)
+    IO.puts("============================================================")
+    create_config(IO.inspect(mix_config), IO.inspect(user_config))
+    IO.puts("============================================================")
   end
 
   @doc "Generate cfg based on params"

--- a/lib/mix/tasks/systemd.ex
+++ b/lib/mix/tasks/systemd.ex
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Systemd do
           user_config[:app_name]
 
         is_nil(mix_config[:app]) and Mix.Project.umbrella?() ->
-          mix_config[:default_release] || Enum.at(mix_config[:releases], 0)
+          mix_config[:default_release] || Enum.at(mix_config[:releases], 0) |> elem(0)
       end
 
     # External name, used for files and directories

--- a/lib/mix/tasks/systemd.ex
+++ b/lib/mix/tasks/systemd.ex
@@ -237,10 +237,10 @@ defmodule Mix.Tasks.Systemd do
     ]
 
     # Override values from user config
-    IO.inspect(defaults)
-    IO.inspect(user_config)
+    IO.inspect(defaults[:app_name])
+    IO.inspect(user_config[:app_name])
     cfg = Keyword.merge(defaults, user_config)
-    IO.inspect(cfg)
+    IO.inspect(cfg[:app_name])
 
     # Calcualate values from other things
     cfg =

--- a/lib/mix/tasks/systemd.ex
+++ b/lib/mix/tasks/systemd.ex
@@ -20,8 +20,9 @@ defmodule Mix.Tasks.Systemd do
     mix_config = Mix.Project.config()
 
     IO.puts("============================================================")
-    create_config(IO.inspect(mix_config), IO.inspect(user_config))
+    cfg = create_config(IO.inspect(mix_config), IO.inspect(user_config))
     IO.puts("============================================================")
+    cfg
   end
 
   @doc "Generate cfg based on params"


### PR DESCRIPTION
The `app_name` value is used to set many of the other config values, which makes it very complicated if you need to use a different app name... you cannot simply set the app name in a config block, since the user_configs get merged only after all of the config values that are set by the app_name are set, so you need to know and change all of the configs that are affected by the app name value.

This PR allows setting the app name in the config, and makes sure that this value trickles down to all of the relevant configs. We also add a sane default for umbrella apps, which do not contain an `:app` key in their Mix.Project.config, by using the default release (or the only release) name as the app name.